### PR TITLE
Don't throw an error if config.filetypes is nil

### DIFF
--- a/lua/lspconfig/configs.lua
+++ b/lua/lspconfig/configs.lua
@@ -250,6 +250,11 @@ function configs.__newindex(t, config_name, config_def)
 
     function manager.try_add_wrapper(bufnr)
       local buf_filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
+
+      if not config.filetypes then
+        return
+      end
+
       for _, filetype in ipairs(config.filetypes) do
         if buf_filetype == filetype then
           manager.try_add(bufnr)


### PR DESCRIPTION
Without this neovim would show an error after each PackerCompile